### PR TITLE
[feat] Make gitsigns init function async (#2538)

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -96,13 +96,18 @@ local default_plugins = {
       vim.api.nvim_create_autocmd({ "BufRead" }, {
         group = vim.api.nvim_create_augroup("GitSignsLazyLoad", { clear = true }),
         callback = function()
-          vim.fn.system("git -C " .. '"' .. vim.fn.expand "%:p:h" .. '"' .. " rev-parse")
-          if vim.v.shell_error == 0 then
-            vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
-            vim.schedule(function()
-              require("lazy").load { plugins = { "gitsigns.nvim" } }
-            end)
-          end
+          vim.fn.jobstart({"git", "-C", vim.loop.cwd(), "rev-parse"},
+            {
+              on_exit = function(_, return_code)
+                if return_code == 0 then
+                  vim.api.nvim_del_augroup_by_name "GitSignsLazyLoad"
+                  vim.schedule(function()
+                    require("lazy").load { plugins = { "gitsigns.nvim" } }
+                  end)
+                end
+              end
+            }
+          )
         end,
       })
     end,


### PR DESCRIPTION
* [feat] Make gitsigns init function async

This function is running git and also initializing a shell, which can be a relatively slow operation. By leveraging the jobs api, we run the command in background, reducing the time it takes for the buffer to be available to the user. It also uses the list format for the job, which allow us to bypass the shell entirely.

* performance: use uv.cwd() instead of fn.expand 

benchmarked luv's cwd and it seems to be 20x faster than the expand function

---------